### PR TITLE
we need to have discusison about when to split core and deps

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -17,7 +17,7 @@ Now, connect to the database in your favorite repl.
 
 ```clojure
 (mount/start)
-(pp/print-table (get-tables))
+(pp/print-table (all-tables db)) 
 
 | :pg_namespace/table_schema | :pg_class/table_name | :table_description | :insertable |
 |----------------------------+----------------------+--------------------+-------------|

--- a/example/src/user.clj
+++ b/example/src/user.clj
@@ -1,5 +1,7 @@
 (ns user
   (:require [naptime.db :as db]
+            [naptime.core :as naptime]
+            [ring.mock.request :as mock]
             [clojure.pprint :as pp]
             [next.jdbc.sql :as sql]
             [conman.core :as conman]
@@ -14,5 +16,10 @@
 (defstate queries
   :start (db/load-queries :postgres))
 
-(defn get-tables []
-  (db/query *db* queries :all-tables))
+(defn all-tables [db]
+  (db/query db queries :all-tables))
+
+(defn many-to-one [db]
+  (db/query db queries :many-to-one))
+
+((naptime/handler *db*) (mock/request :get naptime/logical-operators-qs))


### PR DESCRIPTION
currently `user.clj` is an example setting up state that is intended to call naptime as a library (not formalized to necessarily have server component yet, it is just a codepad)

`naptime/core` today is set up with reitit, handler, without any db state (mainly to work on the parsing part)

It is at the point where we need to make a line where the state should live, where it should stay pure functions, and how we can accomplish the goal as embedded library and (secondary goal? ultimate?) as a standalone server.

Even if it is capable of standalone server, I like the idea that we can let any clojure developer extend it "as the main app" using this project template. One can argue they don't like the template / already existing app (or any other good reason) 

Few options I can think of:
**Options A**
naptime as a library, pure functions ala honeysql

server with db connection, HTTP server that calls naptime with docker image, etc that user can just get up and running with bare minimum configuration. Developers primarily extend through SQL schema, stored procedures, etc (ala postgrest / hasura).

Hasura let the developer "extend" by posting webhook out (to another service that the developer would maintain). They have metadata thing (text file you can check in to version control to version your "code"), etc.

**Option B**
naptime as a library (be the focus)

example folder how to use it as a library. This code is just a pure example. It has to work but it is not expected for developer-user to use it

**Option C**
both option A and B

Option A boils down to how we want to approach authentication/authorization (and all the concern of building an application server). Option A broadens the scope **significantly**. Something we should be very much aware of. I prefer being able to show to the public much faster

Option B is something that we can dogfood right away i.e plug into our main repo. It is something most developers would find interested to try. Perhaps we should look into how [walmartlabs/lacinia](https://github.com/walmartlabs/lacinia) is approaching this. We are basically doing the same thing one with rest vs. graphql

Edit: I looked through lacinia code. It focuses on exposing just the code (parser, validation, etc). They don't tie into HTTP handler providing keywordize query string, or have any need to introspect database (jdbc)

Essentially, as a library we would expose (naptime/nap schema-cache ring-request) returning honeysql-map

Interesting! this is example it tap to pedestal as interceptor! https://github.com/walmartlabs/lacinia-pedestal/tree/master/src/com/walmartlabs/lacinia